### PR TITLE
allow redis options to accept url

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,21 @@ const FIVE_MINUTES = 5 * 60;
 
 class RedisCache {
   constructor(options) {
-    let client = this.client = redis.createClient({
-      host: options.host,
-      port: options.port
-    });
+    var redisOptions = options;
+
+    if (options.url) {
+      redisOptions = this._stripUsernameFromConfigUrl(options.url);
+    } else {
+      redisOptions = {
+        host: options.host,
+        port: options.port
+      };
+      if (options.password) {
+        redisOptions.password = options.password;
+      }
+    }
+
+    let client = this.client = redis.createClient(redisOptions);
 
     this.expiration = options.expiration || FIVE_MINUTES;
     this.connected = false;
@@ -74,6 +85,17 @@ class RedisCache {
           }
         });
     });
+  }
+
+  _stripUsernameFromConfigUrl(configUrl) {
+    let regex = /redis:\/\/(\w+):(\w+)(.*)/;
+    let matches = configUrl.match(regex);
+
+    if (matches) {
+      configUrl = 'redis://:' + matches[2] + matches[3];
+    }
+
+    return configUrl;
   }
 }
 

--- a/test/caching-test.js
+++ b/test/caching-test.js
@@ -62,6 +62,30 @@ describe('caching tests', function() {
     });
   });
 
+  describe('redis options tests', function() {
+    it('accepts redis password', function() {
+      cache = new RedisCache({
+        host: "127.0.0.1",
+        port: "6379",
+        password: "some-password"
+      });
+      expect(cache.client.options.host).to.equal('127.0.0.1');
+      expect(cache.client.options.port).to.equal('6379');
+      expect(cache.client.options.password).to.equal('some-password');
+    });
+
+    it('uses redis url instead of host and port when url is provided', function() {
+      cache = new RedisCache({
+        host: "127.0.0.1",
+        port: "6379",
+        url: "redis://some-user:some-password@some-host.com:1234"
+      });
+      expect(cache.client.options.host).to.equal('some-host.com');
+      expect(cache.client.options.port).to.equal('1234');
+      expect(cache.client.options.password).to.equal('some-password');
+    });
+  });
+
   describe('custom keys tests', function() {
     beforeEach(function() {
       cache = new RedisCache({


### PR DESCRIPTION
If url is defined, then host, port and password are not needed.
