### PR TITLE
Doesn't cache 3xx response

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ class RedisCache {
       let statusCodeStr = statusCode && (statusCode + '');
 
       if (statusCodeStr && statusCodeStr.length &&
-         (statusCodeStr.charAt(0) === '4' || statusCodeStr.charAt(0) === '5')) {
+         (statusCodeStr.charAt(0) === '4' || statusCodeStr.charAt(0) === '5' || statusCodeStr.charAt(0) === '3')) {
         res();
         return;
       }

--- a/test/caching-test.js
+++ b/test/caching-test.js
@@ -60,6 +60,15 @@ describe('caching tests', function() {
         expect(mockRedis['/']).to.be.undefined;
       });
     });
+    
+    it('does not cache 3xx error responses', function() {
+      let body = '<body>Redirect to </body>';
+      let mockResponse = { statusCode: 301 };
+
+      return cache.put('/', body, mockResponse).then(() => {
+        expect(mockRedis['/']).to.be.undefined;
+      });
+    });
   });
 
   describe('custom keys tests', function() {


### PR DESCRIPTION
Hi 

I faced with an issue:

I have redirect from / to other page. Fastboot responds with this body https://github.com/ember-fastboot/fastboot/blob/master/src/result.js#L42 and 301 status. Body cached in redis and a response for next request has 200. 

I think that responses with 3xx statuses should be ignored.