### PR TITLE
Added password option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ let cache = new RedisCache({
   }
 });
 ```
+
+You can specify Redis authentication password if your server requires it.
+
+```js
+let cache = new RedisCache({
+  host: FASTBOOT_REDIS_HOST,
+  port: FASTBOOT_REDIS_PORT,
+  password: FASTBOOT_REDIS_PASSWORD
+});
+```

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ class RedisCache {
 
       this.client.multi()
         .set(key, body)
-        .expire(path, this.expiration)
+        .expire(key, this.expiration)
         .exec(err => {
           if (err) {
             rej(err);

--- a/index.js
+++ b/index.js
@@ -6,10 +6,17 @@ const FIVE_MINUTES = 5 * 60;
 
 class RedisCache {
   constructor(options) {
-    let client = this.client = redis.createClient({
+
+    let clientOptions = {
       host: options.host,
       port: options.port
-    });
+    };
+
+    if (options.password) {
+      clientOptions.password = options.password;
+    }
+
+    let client = this.client = redis.createClient(clientOptions);
 
     this.expiration = options.expiration || FIVE_MINUTES;
     this.connected = false;


### PR DESCRIPTION
Redis Labs requires a password for their Redis servers. This PR adds an option to specify a password via RedisCache constructor option.