### PR TITLE
Error with expire when use custom cacheKey

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class RedisCache {
 
       this.client.multi()
         .set(key, body)
-        .expire(path, this.expiration)
+        .expire(key, this.expiration)
         .exec(err => {
           if (err) {
             rej(err);

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ class RedisCache {
       let statusCodeStr = statusCode && (statusCode + '');
 
       if (statusCodeStr && statusCodeStr.length &&
-         (statusCodeStr.charAt(0) === '4' || statusCodeStr.charAt(0) === '5')) {
+         (statusCodeStr.charAt(0) === '4' || statusCodeStr.charAt(0) === '5' || statusCodeStr.charAt(0) === '3')) {
         res();
         return;
       }

--- a/test/caching-test.js
+++ b/test/caching-test.js
@@ -60,6 +60,15 @@ describe('caching tests', function() {
         expect(mockRedis['/']).to.be.undefined;
       });
     });
+    
+    it('does not cache 3xx error responses', function() {
+      let body = '<body>Redirect to </body>';
+      let mockResponse = { statusCode: 301 };
+
+      return cache.put('/', body, mockResponse).then(() => {
+        expect(mockRedis['/']).to.be.undefined;
+      });
+    });
   });
 
   describe('custom keys tests', function() {


### PR DESCRIPTION
When I set cacheKey as 'fastboot:' and request /
```
redis-cli ttl fastboot:/
```
returns -1