### PR TITLE
fix expire function for custom keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class RedisCache {
 
       this.client.multi()
         .set(key, body)
-        .expire(path, this.expiration)
+        .expire(key, this.expiration)
         .exec(err => {
           if (err) {
             rej(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastboot-redis-cache",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A FastBoot App Server cache for Redis",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
should use `key` (derived from `cacheKey` function) instead of original `path` when doing all redis commands.
